### PR TITLE
Fix pagination page count

### DIFF
--- a/src/main/java/kkmm/back/board/domain/Service/NoteService.java
+++ b/src/main/java/kkmm/back/board/domain/Service/NoteService.java
@@ -76,10 +76,12 @@ public class NoteService {
     }
 
     public Long countTotalPages() {
-        return (noteRepository.count() / 10) + 1;
+        long count = noteRepository.count();
+        return (count - 1) / 10 + 1;
     }
 
     public Long countSearchedPages(String keyword, String searchType) {
-        return (noteQueryRepository.countSearchedNotes(searchType, keyword) / 10) + 1;
+        long count = noteQueryRepository.countSearchedNotes(searchType, keyword);
+        return (count - 1) / 10 + 1;
     }
 }


### PR DESCRIPTION
## Summary
- correct total page calculations in NoteService to avoid an extra page when total notes are multiples of ten

## Testing
- `sh gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_687e6b36b7b08333a915b324f7ecaaa8