### PR TITLE
Refactor tests with shared support

### DIFF
--- a/src/test/java/kkmm/back/board/IntegrationTestSupport.java
+++ b/src/test/java/kkmm/back/board/IntegrationTestSupport.java
@@ -1,0 +1,69 @@
+package kkmm.back.board;
+
+import kkmm.back.board.domain.Service.*;
+import kkmm.back.board.domain.dto.CommentDto;
+import kkmm.back.board.domain.dto.SignupDto;
+import kkmm.back.board.domain.model.*;
+import kkmm.back.board.domain.repository.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@SpringBootTest
+@Transactional
+public abstract class IntegrationTestSupport {
+
+    @Autowired protected MemberService memberService;
+    @Autowired protected CategoryService categoryService;
+    @Autowired protected CommentService commentService;
+    @Autowired protected NoteService noteService;
+
+    @Autowired protected NoteRepository noteRepository;
+    @Autowired protected MemberRepository memberRepository;
+    @Autowired protected CategoryRepository categoryRepository;
+    @Autowired protected CommentRepository commentRepository;
+    @Autowired protected NoteQueryRepository noteQueryRepository;
+
+    protected Member joinMember(String email, String password, String name) {
+        SignupDto dto = new SignupDto(email, password, name);
+        Long id = memberService.join(dto);
+        return memberService.findById(id);
+    }
+
+    protected Category createCategory(String name) {
+        Long id = categoryService.save(new Category(name));
+        return categoryService.findById(id);
+    }
+
+    protected void saveSampleNotes(Category category, Member member) {
+        LocalDateTime baseTime = LocalDateTime.now().minusDays(10);
+        List<Note> notes = List.of(
+                new Note(member, "1", "1", category),
+                new Note(member, "2", "2", category),
+                new Note(member, "3", "3", category),
+                new Note(member, "4", "4", category),
+                new Note(member, "5", "5", category),
+                new Note(member, "6", "6", category),
+                new Note(member, "7", "7", category),
+                new Note(member, "8", "8", category),
+                new Note(member, "9", "9", category),
+                new Note(member, "10", "10", category)
+        );
+        for (int i = 0; i < notes.size(); i++) {
+            notes.get(i).setCreatedAt(baseTime.plusDays(i));
+        }
+        noteRepository.saveAll(notes);
+    }
+
+    protected void saveSampleComments(Member member, List<Note> notes) throws InterruptedException {
+        for (int i = notes.size() - 1; i >= 0; i--) {
+            CommentDto dto = new CommentDto();
+            dto.setNoteId(notes.get(i).getId());
+            commentService.save(dto, member);
+            Thread.sleep(10);
+        }
+    }
+}

--- a/src/test/java/kkmm/back/board/domain/Service/CategoryServiceTest.java
+++ b/src/test/java/kkmm/back/board/domain/Service/CategoryServiceTest.java
@@ -1,11 +1,9 @@
 package kkmm.back.board.domain.Service;
 
-import jakarta.transaction.Transactional;
 import kkmm.back.board.domain.model.Category;
-import lombok.extern.slf4j.Slf4j;
+import kkmm.back.board.IntegrationTestSupport;
+import kkmm.back.board.domain.Service.CategoryService;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -13,13 +11,7 @@ import java.util.NoSuchElementException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@SpringBootTest
-@Slf4j
-@Transactional
-class CategoryServiceTest {
-
-    @Autowired
-    CategoryService categoryService;
+class CategoryServiceTest extends IntegrationTestSupport {
 
     @Test
     public void 카테고리_저장() throws Exception {

--- a/src/test/java/kkmm/back/board/domain/Service/CommentServiceTest.java
+++ b/src/test/java/kkmm/back/board/domain/Service/CommentServiceTest.java
@@ -1,44 +1,24 @@
 package kkmm.back.board.domain.Service;
 
-import jakarta.transaction.Transactional;
+import kkmm.back.board.IntegrationTestSupport;
 import kkmm.back.board.domain.dto.CommentDto;
 import kkmm.back.board.domain.model.Category;
 import kkmm.back.board.domain.model.Comment;
 import kkmm.back.board.domain.model.Member;
 import kkmm.back.board.domain.model.Note;
-import kkmm.back.board.domain.repository.CategoryRepository;
-import kkmm.back.board.domain.repository.MemberRepository;
-import kkmm.back.board.domain.repository.NoteRepository;
-import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@Transactional
-@SpringBootTest
-@Slf4j
-class CommentServiceTest {
+class CommentServiceTest extends IntegrationTestSupport {
 
-    @Autowired
-    CommentService commentService;
-
-    @Autowired
-    NoteRepository noteRepository;
-
-    @Autowired
-    MemberRepository memberRepository;
-
-    @Autowired
-    CategoryRepository categoryRepository;
 
     @Test
     public void 댓글_저장() throws Exception {
         //given
-        Member member = memberRepository.save(new Member("a", "a", "a"));
-        Category category = categoryRepository.save(new Category("dummy"));
+        Member member = joinMember("a", "a", "a");
+        Category category = createCategory("dummy");
         Note note = noteRepository.save(new Note(member, "a", "a", category));
 
         CommentDto commentDto = new CommentDto();
@@ -60,8 +40,8 @@ class CommentServiceTest {
     @Test
     public void 대댓글_저장() throws Exception {
         //given
-        Member member = memberRepository.save(new Member("a", "a", "a"));
-        Category category = categoryRepository.save(new Category("dummy"));
+        Member member = joinMember("a", "a", "a");
+        Category category = createCategory("dummy");
         Note note = noteRepository.save(new Note(member, "a", "a", category));
 
         CommentDto parentDto = new CommentDto();
@@ -88,8 +68,8 @@ class CommentServiceTest {
     @Test
     public void 댓글_수정() throws Exception {
         //given
-        Member member = memberRepository.save(new Member("a", "a", "a"));
-        Category category = categoryRepository.save(new Category("dummy"));
+        Member member = joinMember("a", "a", "a");
+        Category category = createCategory("dummy");
         Note note = noteRepository.save(new Note(member, "a", "a", category));
 
         CommentDto commentDto = new CommentDto();

--- a/src/test/java/kkmm/back/board/domain/Service/NoteServiceTest.java
+++ b/src/test/java/kkmm/back/board/domain/Service/NoteServiceTest.java
@@ -1,39 +1,28 @@
 package kkmm.back.board.domain.Service;
 
-import jakarta.persistence.EntityManager;
+import kkmm.back.board.IntegrationTestSupport;
 import kkmm.back.board.domain.dto.NoteDto;
-import kkmm.back.board.domain.dto.SignupDto;
 import kkmm.back.board.domain.model.Category;
 import kkmm.back.board.domain.model.Member;
 import kkmm.back.board.domain.model.Note;
-import kkmm.back.board.domain.repository.NoteRepository;
 import kkmm.back.board.web.dto.NoteForm;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest
-@Transactional
 @Slf4j
-class NoteServiceTest {
+class NoteServiceTest extends IntegrationTestSupport {
 
-    @Autowired NoteService noteService;
-    @Autowired MemberService memberService;
-    @Autowired NoteRepository noteRepository;
-    @Autowired CategoryService categoryService;
 
     @Test
     public void 게시글_저장() throws Exception {
         //given
         Member member = joinMember("a", "1", "2");
-        Category category = makeCategory();
+        Category category = createCategory("default");
         NoteDto noteDto = new NoteDto();
         noteDto.setTitle("title");
         noteDto.setContents("content");
@@ -52,8 +41,8 @@ class NoteServiceTest {
     public void 게시글_페이지_받아오기() throws Exception {
         //given
         Member member = joinMember("a", "1", "2");
-        Category category = makeCategory();
-        save_sample_notes(category, member);
+        Category category = createCategory("default");
+        saveSampleNotes(category, member);
 
         //when
         List<Note> notes = noteService.findNotes(1);
@@ -68,8 +57,8 @@ class NoteServiceTest {
     public void 검색_게시글_페이지_받아오기() throws Exception {
         //given
         Member member = joinMember("a", "a", "a");
-        Category category = makeCategory();
-        save_sample_notes(category, member);
+        Category category = createCategory("default");
+        saveSampleNotes(category, member);
 
         //when
         List<Note> searchAuthor = noteService.searchNotes(1, "a" ,"author");
@@ -92,7 +81,7 @@ class NoteServiceTest {
     public void 게시글_업데이트() throws Exception {
         //given
         Member member = joinMember("a", "1", "2");
-        Category category = makeCategory();
+        Category category = createCategory("default");
         NoteDto noteDto = new NoteDto();
         noteDto.setTitle("title");
         noteDto.setContents("content");
@@ -111,37 +100,5 @@ class NoteServiceTest {
         assertThat(updateNote.getContent()).isEqualTo("updateContent");
     }
 
-    private Member joinMember(String email, String password, String name) throws Exception {
-        SignupDto signupDto = new SignupDto(email, password, name);
-        Long joinId = memberService.join(signupDto);
-        return memberService.findById(joinId);
-    }
 
-    public void save_sample_notes(Category category, Member member) {
-        LocalDateTime baseTime = LocalDateTime.now().minusDays(10);
-
-        List<Note> notes = List.of(
-                new Note(member, "1", "1", category),
-                new Note(member, "2", "2", category),
-                new Note(member, "3", "3", category),
-                new Note(member, "4", "4", category),
-                new Note(member, "5", "5", category),
-                new Note(member, "6", "6", category),
-                new Note(member, "7", "7", category),
-                new Note(member, "8", "8", category),
-                new Note(member, "9", "9", category),
-                new Note(member, "10", "10", category)
-        );
-
-        for (int i = 0; i < 10; i++) {
-            notes.get(i).setCreatedAt(baseTime.plusDays(i));
-        }
-
-        noteRepository.saveAll(notes);
-    }
-
-    private Category makeCategory() {
-        Long categoryId = categoryService.save(new Category("default"));
-        return categoryService.findById(categoryId);
-    }
 }

--- a/src/test/java/kkmm/back/board/domain/repository/NoteQueryRepositoryTest.java
+++ b/src/test/java/kkmm/back/board/domain/repository/NoteQueryRepositoryTest.java
@@ -1,38 +1,25 @@
 package kkmm.back.board.domain.repository;
 
+import kkmm.back.board.IntegrationTestSupport;
 import kkmm.back.board.domain.model.Category;
 import kkmm.back.board.domain.model.Member;
 import kkmm.back.board.domain.model.Note;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest
 @Slf4j
-@Transactional
-class NoteQueryRepositoryTest {
+class NoteQueryRepositoryTest extends IntegrationTestSupport {
 
-    @Autowired
-    NoteQueryRepository noteQueryRepository;
-
-    @Autowired
-    NoteRepository noteRepository;
-    @Autowired
-    CategoryRepository categoryRepository;
-    @Autowired
-    MemberRepository memberRepository;
 
     @Test
     public void 게시글_범위_찾기() throws Exception {
         //given
-        save_sample_notes();
+        saveSampleNotes();
 
         //when
         List<Note> findNotes = noteQueryRepository.findNoteRange(4, 4);
@@ -48,7 +35,7 @@ class NoteQueryRepositoryTest {
     @Test
     public void 게시글_검색_범위_찾기() throws Exception {
         //given
-        save_sample_notes();
+        saveSampleNotes();
 
         //when
         List<Note> findNotes1 = noteQueryRepository.searchNotesRange("title", "2", 0, 10);
@@ -72,7 +59,7 @@ class NoteQueryRepositoryTest {
     @Test
     public void 검색된_게시글수_찾기() throws Exception {
         //given
-        save_sample_notes();
+        saveSampleNotes();
 
         //when
         Long s1 = noteQueryRepository.countSearchedNotes("title", "3" );
@@ -83,12 +70,9 @@ class NoteQueryRepositoryTest {
         assertThat(s2).isEqualTo(4L);
     }
 
-    public void save_sample_notes() {
-        Category category = new Category("1");
-        categoryRepository.save(category);
-
-        Member member1 = new Member("1", "1", "1");
-        memberRepository.save(member1);
+    private void saveSampleNotes() {
+        Category category = createCategory("1");
+        Member member1 = joinMember("1", "1", "1");
 
         LocalDateTime baseTime = LocalDateTime.now();
 


### PR DESCRIPTION
## Summary
- introduce `IntegrationTestSupport` for bootstrapping service and repository tests
- update service and repository tests to extend the new base class and reuse helper methods

## Testing
- `./gradlew test --no-build-cache` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_687e805c1bfc83339b084d8154f0cada