### PR TITLE
Add controller layer tests

### DIFF
--- a/src/test/java/kkmm/back/board/ControllerTestSupport.java
+++ b/src/test/java/kkmm/back/board/ControllerTestSupport.java
@@ -1,0 +1,14 @@
+package kkmm.back.board;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.test.web.servlet.MockMvc;
+
+@AutoConfigureMockMvc
+@Transactional
+public abstract class ControllerTestSupport extends IntegrationTestSupport {
+
+    @Autowired
+    protected MockMvc mockMvc;
+}

--- a/src/test/java/kkmm/back/board/web/controller/BoardControllerTest.java
+++ b/src/test/java/kkmm/back/board/web/controller/BoardControllerTest.java
@@ -1,0 +1,38 @@
+package kkmm.back.board.web.controller;
+
+import kkmm.back.board.ControllerTestSupport;
+import kkmm.back.board.domain.model.Category;
+import kkmm.back.board.domain.model.Member;
+import org.junit.jupiter.api.Test;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+class BoardControllerTest extends ControllerTestSupport {
+
+    @Test
+    void 게시글_목록_페이지() throws Exception {
+        Member member = joinMember("board@test.com", "1", "board");
+        Category category = createCategory("cat");
+        saveSampleNotes(category, member);
+
+        mockMvc.perform(get("/board/list"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("form/listForm"))
+                .andExpect(model().attributeExists("notes", "totalPages", "categoryForm"));
+    }
+
+    @Test
+    void 게시글_검색_페이지() throws Exception {
+        Member member = joinMember("board2@test.com", "1", "board");
+        Category category = createCategory("cat2");
+        saveSampleNotes(category, member);
+
+        mockMvc.perform(get("/board/search")
+                        .param("searchType", "title")
+                        .param("keyword", "1")
+                        .param("page", "1"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("form/listForm"));
+    }
+}

--- a/src/test/java/kkmm/back/board/web/controller/CategoryControllerTest.java
+++ b/src/test/java/kkmm/back/board/web/controller/CategoryControllerTest.java
@@ -1,0 +1,35 @@
+package kkmm.back.board.web.controller;
+
+import kkmm.back.board.ControllerTestSupport;
+import kkmm.back.board.domain.model.Member;
+import kkmm.back.board.web.SessionConst;
+import org.junit.jupiter.api.Test;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+class CategoryControllerTest extends ControllerTestSupport {
+
+    @Test
+    void 카테고리_관리_페이지() throws Exception {
+        Member member = joinMember("cat@test.com", "1", "name");
+
+        mockMvc.perform(get("/category/manage")
+                        .sessionAttr(SessionConst.LOGIN_MEMBER, member))
+                .andExpect(status().isOk())
+                .andExpect(view().name("form/manageCategoryForm"))
+                .andExpect(model().attributeExists("categories", "categoryForm"));
+    }
+
+    @Test
+    void 카테고리_생성() throws Exception {
+        Member member = joinMember("cat2@test.com", "1", "name");
+
+        mockMvc.perform(post("/category/create")
+                        .sessionAttr(SessionConst.LOGIN_MEMBER, member)
+                        .param("name", "new"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("form/manageCategoryForm"));
+    }
+}

--- a/src/test/java/kkmm/back/board/web/controller/CommentControllerTest.java
+++ b/src/test/java/kkmm/back/board/web/controller/CommentControllerTest.java
@@ -1,0 +1,31 @@
+package kkmm.back.board.web.controller;
+
+import kkmm.back.board.ControllerTestSupport;
+import kkmm.back.board.domain.dto.NoteDto;
+import kkmm.back.board.domain.model.Category;
+import kkmm.back.board.domain.model.Member;
+import kkmm.back.board.web.SessionConst;
+import org.junit.jupiter.api.Test;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class CommentControllerTest extends ControllerTestSupport {
+
+    @Test
+    void 댓글_작성() throws Exception {
+        Member member = joinMember("comment@test.com", "1", "name");
+        Category category = createCategory("cat");
+        NoteDto dto = new NoteDto();
+        dto.setTitle("t");
+        dto.setContents("c");
+        Long id = noteService.save(dto, member, category);
+
+        mockMvc.perform(post("/comment/create/{id}", id)
+                        .sessionAttr(SessionConst.LOGIN_MEMBER, member)
+                        .param("contents", "hello"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/note/view/" + id));
+    }
+}

--- a/src/test/java/kkmm/back/board/web/controller/HomeControllerTest.java
+++ b/src/test/java/kkmm/back/board/web/controller/HomeControllerTest.java
@@ -1,0 +1,17 @@
+package kkmm.back.board.web.controller;
+
+import kkmm.back.board.ControllerTestSupport;
+import org.junit.jupiter.api.Test;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+class HomeControllerTest extends ControllerTestSupport {
+
+    @Test
+    void 루트_리다이렉트() throws Exception {
+        mockMvc.perform(get("/"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/board/list"));
+    }
+}

--- a/src/test/java/kkmm/back/board/web/controller/MemberControllerTest.java
+++ b/src/test/java/kkmm/back/board/web/controller/MemberControllerTest.java
@@ -1,0 +1,43 @@
+package kkmm.back.board.web.controller;
+
+import kkmm.back.board.ControllerTestSupport;
+import kkmm.back.board.web.SessionConst;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.Matchers.notNullValue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+class MemberControllerTest extends ControllerTestSupport {
+
+    @Test
+    void 로그인_폼() throws Exception {
+        mockMvc.perform(get("/member/login"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("member/loginForm"));
+    }
+
+    @Test
+    void 회원가입() throws Exception {
+        mockMvc.perform(post("/member/signup")
+                        .param("email", "new@test.com")
+                        .param("password", "pw")
+                        .param("name", "name"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/board/list"));
+    }
+
+    @Test
+    void 로그인() throws Exception {
+        joinMember("user@test.com", "pw", "name");
+
+        mockMvc.perform(post("/member/login")
+                        .param("email", "user@test.com")
+                        .param("password", "pw")
+                        .param("redirectURL", "/board/list"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/board/list"))
+                .andExpect(request().sessionAttribute(SessionConst.LOGIN_MEMBER, notNullValue()));
+    }
+}

--- a/src/test/java/kkmm/back/board/web/controller/NoteControllerTest.java
+++ b/src/test/java/kkmm/back/board/web/controller/NoteControllerTest.java
@@ -1,0 +1,42 @@
+package kkmm.back.board.web.controller;
+
+import kkmm.back.board.ControllerTestSupport;
+import kkmm.back.board.domain.dto.NoteDto;
+import kkmm.back.board.domain.model.Category;
+import kkmm.back.board.domain.model.Member;
+import kkmm.back.board.web.SessionConst;
+import org.junit.jupiter.api.Test;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+class NoteControllerTest extends ControllerTestSupport {
+
+    @Test
+    void 글쓰기_폼() throws Exception {
+        Member member = joinMember("note@test.com", "1", "name");
+        createCategory("cat");
+
+        mockMvc.perform(get("/note/write")
+                        .sessionAttr(SessionConst.LOGIN_MEMBER, member))
+                .andExpect(status().isOk())
+                .andExpect(view().name("form/writeNoteForm"))
+                .andExpect(model().attributeExists("categories", "note"));
+    }
+
+    @Test
+    void 게시글_조회() throws Exception {
+        Member member = joinMember("note2@test.com", "1", "name");
+        Category category = createCategory("cat2");
+        NoteDto dto = new NoteDto();
+        dto.setTitle("t");
+        dto.setContents("c");
+        Long id = noteService.save(dto, member, category);
+
+        mockMvc.perform(get("/note/view/{id}", id)
+                        .sessionAttr(SessionConst.LOGIN_MEMBER, member))
+                .andExpect(status().isOk())
+                .andExpect(view().name("form/viewNoteForm"))
+                .andExpect(model().attributeExists("note", "comments", "updateComment", "newComment"));
+    }
+}


### PR DESCRIPTION
## Summary
- add `ControllerTestSupport` for MockMvc-based tests
- implement controller tests for board, home, category, note, member and comment endpoints

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_687f7a3b298883338d0c363499523a65