### PR TITLE
Add NoteController tests for edit, delete, and file upload

### DIFF
--- a/src/test/java/kkmm/back/board/web/controller/NoteControllerTest.java
+++ b/src/test/java/kkmm/back/board/web/controller/NoteControllerTest.java
@@ -7,7 +7,14 @@ import kkmm.back.board.domain.model.Member;
 import kkmm.back.board.web.SessionConst;
 import org.junit.jupiter.api.Test;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.io.File;
+import java.util.NoSuchElementException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 class NoteControllerTest extends ControllerTestSupport {
@@ -38,5 +45,63 @@ class NoteControllerTest extends ControllerTestSupport {
                 .andExpect(status().isOk())
                 .andExpect(view().name("form/viewNoteForm"))
                 .andExpect(model().attributeExists("note", "comments", "updateComment", "newComment"));
+    }
+
+    @Test
+    void 게시글_수정() throws Exception {
+        Member member = joinMember("edit@test.com", "1", "name");
+        Category category = createCategory("cat");
+        NoteDto dto = new NoteDto();
+        dto.setTitle("title");
+        dto.setContents("content");
+        Long id = noteService.save(dto, member, category);
+
+        mockMvc.perform(put("/note/edit/{id}", id)
+                        .sessionAttr(SessionConst.LOGIN_MEMBER, member)
+                        .param("title", "newTitle")
+                        .param("contents", "newContent"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/note/view/" + id));
+
+        assertThat(noteService.findById(id).getTitle()).isEqualTo("newTitle");
+    }
+
+    @Test
+    void 게시글_삭제() throws Exception {
+        Member member = joinMember("delete@test.com", "1", "name");
+        Category category = createCategory("cat");
+        NoteDto dto = new NoteDto();
+        dto.setTitle("title");
+        dto.setContents("content");
+        Long id = noteService.save(dto, member, category);
+
+        mockMvc.perform(delete("/note/delete/{id}", id)
+                        .sessionAttr(SessionConst.LOGIN_MEMBER, member))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/board/list"));
+
+        assertThatThrownBy(() -> noteService.findById(id)).isInstanceOf(NoSuchElementException.class);
+    }
+
+    @Test
+    void 게시글_파일_업로드() throws Exception {
+        Member member = joinMember("file@test.com", "1", "name");
+        Category category = createCategory("cat");
+
+        MockMultipartFile file = new MockMultipartFile("files", "hello.txt", "text/plain", "hello".getBytes());
+
+        mockMvc.perform(multipart("/note/write")
+                        .file(file)
+                        .param("title", "title")
+                        .param("contents", "content")
+                        .param("categoryId", category.getId().toString())
+                        .sessionAttr(SessionConst.LOGIN_MEMBER, member))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrlPattern("/note/view/*"));
+
+        Long savedId = noteRepository.findAll().get(0).getId();
+        assertThat(noteService.findById(savedId).getFiles()).hasSize(1);
+        File savedFile = new File("files/" + noteService.findById(savedId).getFiles().get(0).getStoreFileName());
+        assertThat(savedFile.exists()).isTrue();
     }
 }


### PR DESCRIPTION
## Summary
- extend `NoteControllerTest`
  - add new tests for editing notes
  - add new tests for deleting notes
  - add new tests for uploading attachment files to a note

## Testing
- `./gradlew test` *(fails: unable to download Gradle distribution)*

------
https://chatgpt.com/codex/tasks/task_e_687fb812a2b0833392cc1b04dba2d78f